### PR TITLE
Release 0.2.0: Add cached vs uncached cost analysis

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,156 @@
+# Migration Guide: llm-cost-utils 0.1.0 → 0.2.0
+
+This guide will help you migrate from llm-cost-utils 0.1.0 to 0.2.0.
+
+## Breaking Changes
+
+### ✨ Enhanced `calculateRequestCost` Function
+
+The `calculateRequestCost` function now returns comprehensive cost analytics instead of a simple cost breakdown.
+
+#### **Before (0.1.0):**
+```typescript
+interface RequestCost {
+  inputCost: number
+  outputCost: number
+  cacheReadCost: number
+  cacheWriteCost: number
+  totalCost: number
+}
+
+const cost = calculateRequestCost(model, cacheMissTokens, outputTokens, cacheHitTokens, cacheWriteTokens)
+console.log(cost.totalCost) // Access total cost
+```
+
+#### **After (0.2.0):**
+```typescript
+interface RequestCostAnalysis {
+  actualCost: CostBreakdown
+  uncachedCost: CostBreakdown
+  savings: SavingsAnalysis
+  cacheStats: CacheStatistics
+}
+
+const analysis = calculateRequestCost(model, cacheMissTokens, outputTokens, cacheHitTokens, cacheWriteTokens)
+console.log(analysis.actualCost.totalCost) // Access total cost
+console.log(analysis.uncachedCost.totalCost) // See what it would cost without cache
+console.log(analysis.savings.percentSaved) // See percentage saved
+console.log(analysis.cacheStats.hitRate) // See cache hit rate
+```
+
+## Migration Steps
+
+### 1. Update Property Access
+
+Replace direct cost property access:
+
+```typescript
+// ❌ Old (0.1.0)
+const cost = calculateRequestCost(...)
+const total = cost.totalCost
+const input = cost.inputCost
+
+// ✅ New (0.2.0)
+const analysis = calculateRequestCost(...)
+const total = analysis.actualCost.totalCost
+const input = analysis.actualCost.inputCost
+```
+
+### 2. Take Advantage of New Features
+
+Now you can access powerful new analytics:
+
+```typescript
+const analysis = calculateRequestCost(model, cacheMissTokens, outputTokens, cacheHitTokens, cacheWriteTokens)
+
+// 💡 What the request actually cost (with caching)
+console.log(`Actual cost: $${analysis.actualCost.totalCost.toFixed(6)}`)
+
+// 💡 What it would have cost without caching
+console.log(`Uncached cost: $${analysis.uncachedCost.totalCost.toFixed(6)}`)
+
+// 💡 How much you saved
+console.log(`Saved: $${analysis.savings.totalSavings.toFixed(6)} (${analysis.savings.percentSaved.toFixed(1)}%)`)
+
+// 💡 Cache performance metrics
+console.log(`Cache hit rate: ${(analysis.cacheStats.hitRate * 100).toFixed(1)}%`)
+console.log(`Cached tokens: ${analysis.cacheStats.cachedTokens}/${analysis.cacheStats.totalInputTokens}`)
+```
+
+### 3. Update Metadata Storage
+
+If you're storing cost data in metadata:
+
+```typescript
+// ❌ Old (0.1.0)
+const cost = calculateRequestCost(...)
+const metadata = {
+  cost: cost,
+  // ...
+}
+
+// ✅ New (0.2.0) - Comprehensive approach
+const analysis = calculateRequestCost(...)
+const metadata = {
+  cost: analysis.actualCost,        // Backwards compatible
+  costAnalytics: analysis,          // Full analytics
+  // ...
+}
+
+// ✅ New (0.2.0) - Clean approach
+const analysis = calculateRequestCost(...)
+const metadata = {
+  costAnalysis: analysis,
+  // ...
+}
+```
+
+## New Interfaces
+
+### `RequestCostAnalysis`
+Main return type containing all cost analytics.
+
+### `CostBreakdown`
+Detailed cost breakdown (replaces old `RequestCost`):
+```typescript
+interface CostBreakdown {
+  inputCost: number
+  outputCost: number
+  cacheReadCost: number
+  cacheWriteCost: number
+  totalCost: number
+}
+```
+
+### `SavingsAnalysis`
+Cache savings analytics:
+```typescript
+interface SavingsAnalysis {
+  inputSavings: number      // How much saved on input costs
+  totalSavings: number      // Total amount saved
+  percentSaved: number      // Percentage saved (0-100)
+}
+```
+
+### `CacheStatistics`
+Cache performance metrics:
+```typescript
+interface CacheStatistics {
+  hitRate: number           // Cache hit rate (0-1)
+  totalInputTokens: number  // Total input tokens
+  cachedTokens: number      // Tokens served from cache
+  uncachedTokens: number    // Tokens not from cache
+}
+```
+
+## Benefits of Upgrading
+
+- 📊 **Rich Analytics**: Get comprehensive cost insights in a single call
+- 💰 **Savings Tracking**: See exactly how much caching saves you
+- 📈 **Performance Metrics**: Monitor cache hit rates and effectiveness
+- 🎯 **Better Planning**: Compare actual vs uncached costs for budgeting
+- 🔍 **Deeper Insights**: Understand your LLM usage patterns better
+
+## Need Help?
+
+If you have questions about migrating, please check the updated README.md or open an issue in the repository. 

--- a/README.md
+++ b/README.md
@@ -233,9 +233,13 @@ interface RequestCostAnalysis {
 
 ## Model Pricing Updates
 
-To get the latest model pricing, update the `model-prices.json` file in `src/data/`. The library uses this file to calculate accurate costs for each model.
+To get the latest model pricing, run:
 
-For pricing updates or new model support, please [create an issue](https://github.com/augmentedmind/llm-cost-utils/issues) with the model name and pricing information.
+```bash
+npm run download-model-prices
+```
+
+This updates the `model-prices.json` file with current pricing data. For new model support, please [create an issue](https://github.com/augmentedmind/llm-cost-utils/issues) with the model name and pricing information.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ console.log('Cost Analysis:', finalCostAnalysis);
 | Anthropic | ✅ | ✅ | ✅ | ✅ |
 | Google AI | ✅ | ✅ | ✅ | ✅ |
 | Mistral | ✅ | ❌ | ❌ | ✅ |
+| **AI SDK** | ✅ | ✅ | ✅ | ✅ |
+
+> **Note**: AI SDK (Vercel AI SDK) is supported as a response format that wraps any of the above providers
 
 ## Token Usage Output Format
 
@@ -228,29 +231,20 @@ interface RequestCostAnalysis {
 }
 ```
 
-## Troubleshooting
+## Model Pricing Updates
 
-### OpenAI Cached Tokens Not Detected?
+To get the latest model pricing, update the `model-prices.json` file in `src/data/`. The library uses this file to calculate accurate costs for each model.
 
-Make sure your OpenAI responses include the `prompt_tokens_details` field:
+For pricing updates or new model support, please [create an issue](https://github.com/augmentedmind/llm-cost-utils/issues) with the model name and pricing information.
 
-```json
-{
-  "usage": {
-    "prompt_tokens": 2568,
-    "completion_tokens": 268,
-    "prompt_tokens_details": {
-      "cached_tokens": 1280
-    }
-  }
-}
-```
+## Support
 
-### Cost Seems Wrong?
+For issues, questions, or feature requests, please [create an issue](https://github.com/augmentedmind/llm-cost-utils/issues) or start a [discussion](https://github.com/augmentedmind/llm-cost-utils/discussions) in the repository.
 
-- **Cache costs**: Cached tokens typically cost 50% of regular input tokens
-- **Model names**: Use exact model names for accurate pricing
-- **Token breakdown**: Different token types have different rates
+When reporting issues, please include:
+- A minimal reproducible example
+- The exact input and expected vs actual output
+- The model and provider you're using
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,147 +1,54 @@
 # LLM Cost Utils
 
-A utility package for calculating LLM costs and extracting token usage information from API responses.
+A utility library for extracting token usage and calculating LLM costs from API responses.
 
 ## Features
 
-- 🚀 **Enhanced Token Usage Extraction**: Supports multiple LLM provider formats
-- 💰 **Accurate Cost Calculation**: Handles cache hits, cache writes, and reasoning tokens
-- 🔧 **OpenAI Cache Support**: Properly extracts cached tokens from OpenAI's latest response format
-- 📊 **AI SDK Integration**: Seamless integration with Vercel AI SDK
-- 🌐 **Multi-Provider Support**: Works with OpenAI, Anthropic, Google AI, Mistral, and more
-
-## Recent Updates
-
-### OpenAI Cached Tokens Fix (Latest)
-- ✅ **Fixed**: OpenAI cached tokens extraction from `usage.prompt_tokens_details.cached_tokens`
-- ✅ **Enhanced**: Proper calculation of `promptCacheMissTokens` (total - cached)
-- ✅ **Backward Compatible**: Still supports older cache formats from other providers
-
-### Token Usage Extraction Improvements
-- Better handling of different provider response formats
-- More accurate cache hit/miss token calculations
-- Enhanced support for reasoning tokens and prediction tokens
+- 🚀 **Token Usage Extraction**: Extract standardized token usage from various LLM provider response formats
+- 💰 **Cost Analysis**: Calculate comprehensive cost breakdowns including cache savings
+- 🔧 **OpenAI Cache Support**: Properly handles OpenAI's `prompt_tokens_details.cached_tokens` format
+- 📊 **AI SDK Ready**: Seamless integration with Vercel AI SDK responses
+- 🌐 **Multi-Provider**: Works with OpenAI, Anthropic, Google AI, Mistral, and more
 
 ## Installation
 
 ```bash
-# Install from GitHub
 npm install github:augmentedmind/llm-cost-utils
-
-# Or clone and install locally
-git clone git@github.com:augmentedmind/llm-cost-utils.git
-cd llm-cost-utils
-npm install
 ```
 
-## Usage
+## Quick Start
 
 ### Token Usage Extraction
 
-The library now properly handles OpenAI's cached tokens format and other provider formats:
-
 ```typescript
-import { extractTokenUsageFromResponseBody, extractTokenUsageFromResponse } from 'llm-cost-utils';
+import { extractTokenUsageFromResponseBody } from 'llm-cost-utils';
 
-// OpenAI response with cached tokens (NEW FORMAT)
+// OpenAI response with cached tokens
 const openaiResponse = {
-  model: "gpt-4o",
+  model: "gpt-4o-2024-11-20",
   usage: {
     prompt_tokens: 2568,
-    completion_tokens: 571,
-    total_tokens: 3139,
+    completion_tokens: 268,
+    total_tokens: 2836,
     prompt_tokens_details: {
-      cached_tokens: 1280  // ✅ Now properly extracted!
+      cached_tokens: 1280
     }
   }
 };
 
-const openaiTokenUsage = extractTokenUsageFromResponseBody(openaiResponse);
-console.log(openaiTokenUsage);
+const tokenUsage = extractTokenUsageFromResponseBody(openaiResponse);
+console.log(tokenUsage);
+// Output:
 // {
 //   promptCacheMissTokens: 1288,  // 2568 - 1280
-//   promptCacheHitTokens: 1280,   // ✅ Correctly extracted
+//   promptCacheHitTokens: 1280,
 //   reasoningTokens: 0,
-//   completionTokens: 571,
-//   totalOutputTokens: 571,
+//   completionTokens: 268,
+//   totalOutputTokens: 268,
 //   totalInputTokens: 2568,       // 1288 + 1280
 //   promptCacheWriteTokens: 0,
-//   model: "gpt-4o"
+//   model: "gpt-4o-2024-11-20"
 // }
-
-// Standard response without cached tokens
-const responseBody = {
-  usage: {
-    prompt_tokens: 100,
-    completion_tokens: 50,
-    total_tokens: 150
-  }
-};
-
-const tokenUsage = extractTokenUsageFromResponseBody(responseBody);
-console.log(tokenUsage);
-// {
-//   promptCacheMissTokens: 100,
-//   promptCacheHitTokens: 0,
-//   reasoningTokens: 0,
-//   completionTokens: 50,
-//   totalOutputTokens: 50,
-//   totalInputTokens: 100,
-//   promptCacheWriteTokens: 0,
-//   model: undefined
-// }
-
-// AI SDK format (Vercel AI SDK)
-const aiSdkResponse = {
-  model: "gpt-4o",
-  usage: {
-    promptTokens: 91,
-    completionTokens: 38,
-    totalTokens: 129
-  },
-  providerMetadata: {
-    openai: {
-      cachedPromptTokens: 0,
-      reasoningTokens: 0,
-      acceptedPredictionTokens: 0,
-      rejectedPredictionTokens: 0
-    }
-  }
-};
-
-const aiSdkTokenUsage = extractTokenUsageFromResponseBody(aiSdkResponse);
-console.log(aiSdkTokenUsage);
-// {
-//   promptCacheMissTokens: 91,
-//   promptCacheHitTokens: 0,
-//   reasoningTokens: 0,
-//   completionTokens: 38,
-//   totalOutputTokens: 38,
-//   totalInputTokens: 91,
-//   promptCacheWriteTokens: 0,
-//   model: "gpt-4o"
-// }
-
-// Extract token usage from a raw response body (string or object)
-// This can handle both JSON responses and streaming SSE responses
-// It also extracts the model information when available
-const jsonResponse = '{"model":"gpt-4o","usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}';
-const sseResponse = 'data: {"model":"claude-3-haiku-20240307","usage":{"prompt_tokens":100,"completion_tokens":50}}\n\n';
-
-const jsonTokenUsage = extractTokenUsageFromResponse(jsonResponse);
-console.log(jsonTokenUsage);
-// {
-//   promptCacheMissTokens: 100,
-//   promptCacheHitTokens: 0,
-//   reasoningTokens: 0,
-//   completionTokens: 50,
-//   totalOutputTokens: 50,
-//   totalInputTokens: 100,
-//   promptCacheWriteTokens: 0,
-//   model: "gpt-4o"
-// }
-
-const sseTokenUsage = extractTokenUsageFromResponse(sseResponse);
 ```
 
 ### Cost Calculation
@@ -149,226 +56,201 @@ const sseTokenUsage = extractTokenUsageFromResponse(sseResponse);
 ```typescript
 import { calculateRequestCost } from 'llm-cost-utils';
 
-// Calculate cost for a request
-const cost = calculateRequestCost(
+// Calculate comprehensive cost analysis
+const costAnalysis = calculateRequestCost(
   'gpt-4o',                    // model name
-  100,                        // promptCacheMissTokens
-  50,                         // totalOutputTokens
-  0,                          // promptCacheHitTokens (optional)
-  0                           // promptCacheWriteTokens (optional)
+  1288,                        // promptCacheMissTokens
+  268,                         // totalOutputTokens
+  1280,                        // promptCacheHitTokens
+  0                            // promptCacheWriteTokens
 );
 
-console.log(cost);
+console.log(costAnalysis);
+// Output:
 // {
-//   inputCost: 0.03,          // $0.03 for input tokens
-//   outputCost: 0.06,         // $0.06 for output tokens
-//   cacheReadCost: 0,         // $0 for cache reads
-//   cacheWriteCost: 0,        // $0 for cache writes
-//   totalCost: 0.09           // Total cost: $0.09
+//   actualCost: {
+//     inputCost: 0.006440,      // Cost for non-cached input tokens
+//     outputCost: 0.010720,     // Cost for output tokens
+//     cacheReadCost: 0.003200,  // Cost for cached tokens (50% discount)
+//     cacheWriteCost: 0,        // Cost for writing to cache
+//     totalCost: 0.020360       // Total actual cost
+//   },
+//   uncachedCost: {
+//     inputCost: 0.012840,      // What input would cost without caching
+//     outputCost: 0.010720,     // Output cost (same)
+//     cacheReadCost: 0,
+//     cacheWriteCost: 0,
+//     totalCost: 0.023560       // Total without caching
+//   },
+//   savings: {
+//     inputSavings: 0.006400,   // Amount saved on input
+//     totalSavings: 0.003200,   // Total amount saved
+//     percentSaved: 13.58       // Percentage saved
+//   },
+//   cacheStats: {
+//     hitRate: 0.498,           // 49.8% cache hit rate
+//     totalInputTokens: 2568,   // Total input tokens
+//     cachedTokens: 1280,       // Tokens served from cache
+//     uncachedTokens: 1288      // Tokens not in cache
+//   }
 // }
 ```
 
-### Full Example with Response Storage and Model Auto-Detection
+## Complete Example
 
 ```typescript
-import { calculateRequestCost, extractTokenUsageFromResponse } from 'llm-cost-utils';
+import { extractTokenUsageFromResponseBody, calculateRequestCost } from 'llm-cost-utils';
 
-async function processResponse(responseBody: string | object) {
-  // Extract token usage from raw response (includes model when available)
-  const tokenUsage = extractTokenUsageFromResponse(responseBody);
-
-  // Use extracted model if available, or fallback to default
-  const model = tokenUsage.model || 'gpt-4o';
-
-  // Calculate cost using the extracted model
-  const cost = calculateRequestCost(
-    model,
+async function analyzeResponse(responseBody: any) {
+  // Extract token usage
+  const tokenUsage = extractTokenUsageFromResponseBody(responseBody);
+  
+  // Calculate cost analysis
+  const costAnalysis = calculateRequestCost(
+    tokenUsage.model || 'gpt-4o',
     tokenUsage.promptCacheMissTokens,
     tokenUsage.totalOutputTokens,
     tokenUsage.promptCacheHitTokens,
     tokenUsage.promptCacheWriteTokens
   );
-
-  // Store response with metadata
-  const responseWithMetadata = {
-    responseBody,
-    timestamp: new Date().toISOString(),
-    metadata: {
-      model,
-      cost,
-      tokenUsage
-    }
-  };
-
-  // Save to file or database
-  await saveToStorage(responseWithMetadata);
-}
-```
-
-### Integration with AI SDK (Vercel AI SDK)
-
-When using the Vercel AI SDK, you can easily integrate `llm-cost-utils` using the `onFinish` callback:
-
-```typescript
-import { streamObject, generateObject } from 'ai';
-import { calculateRequestCost, extractTokenUsageFromResponse } from 'llm-cost-utils';
-
-// Streaming example
-async function streamingExample() {
-  let finalUsage = null;
-  let finalProviderMetadata = null;
-
-  const { partialObjectStream } = await streamObject({
-    model: yourModel,
-    messages: yourMessages,
-    schema: yourSchema,
-    onFinish({ usage, providerMetadata }) {
-      // Capture usage data from AI SDK
-      finalUsage = usage;
-      finalProviderMetadata = providerMetadata;
-    }
-  });
-
-  // Process stream...
-  for await (const partialObject of partialObjectStream) {
-    // Handle partial results
-    console.log(partialObject);
-  }
-
-  // Calculate cost using AI SDK format
-  if (finalUsage) {
-    const aiSdkUsageData = {
-      model: "gpt-4o", // Your model name
-      usage: finalUsage,
-      providerMetadata: finalProviderMetadata
-    };
-
-    // Extract usage and calculate cost
-    const tokenUsage = extractTokenUsageFromResponse(aiSdkUsageData);
-    const cost = calculateRequestCost(
-      tokenUsage.model || "gpt-4o",
-      tokenUsage.promptCacheMissTokens,
-      tokenUsage.totalOutputTokens,
-      tokenUsage.promptCacheHitTokens,
-      tokenUsage.promptCacheWriteTokens
-    );
-
-    console.log('Cost:', cost);
-    console.log('Token Usage:', tokenUsage);
-  }
-}
-
-// Non-streaming example
-async function nonStreamingExample() {
-  const { object, usage, providerMetadata } = await generateObject({
-    model: yourModel,
-    messages: yourMessages,
-    schema: yourSchema
-  });
-
-  // Create AI SDK format for llm-cost-utils
-  const aiSdkUsageData = {
-    model: "gpt-4o", // Your model name
-    usage: usage,
-    providerMetadata
-  };
-
-  // Extract usage and calculate cost
-  const tokenUsage = extractTokenUsageFromResponse(aiSdkUsageData);
-  const cost = calculateRequestCost(
-    tokenUsage.model || "gpt-4o",
-    tokenUsage.promptCacheMissTokens,
-    tokenUsage.totalOutputTokens,
-    tokenUsage.promptCacheHitTokens,
-    tokenUsage.promptCacheWriteTokens
-  );
-
+  
   return {
-    result: object,
-    cost,
-    tokenUsage
+    tokenUsage,
+    costAnalysis,
+    summary: {
+      model: tokenUsage.model,
+      totalCost: costAnalysis.actualCost.totalCost,
+      savings: costAnalysis.savings.totalSavings,
+      cacheHitRate: costAnalysis.cacheStats.hitRate
+    }
   };
 }
 ```
 
-### Why Use onFinish with AI SDK?
+## AI SDK Integration
 
-The AI SDK's `onFinish` callback provides the cleanest way to capture usage data:
+```typescript
+import { streamObject } from 'ai';
+import { extractTokenUsageFromResponseBody, calculateRequestCost } from 'llm-cost-utils';
 
-- **Consistent Format**: Always returns `{ promptTokens, completionTokens, totalTokens }`
-- **Provider Metadata**: Includes provider-specific details like cached tokens and reasoning tokens
-- **Real-time**: Captures data immediately when the request completes
-- **Works with Streaming**: Available for both streaming and non-streaming requests
+const { partialObjectStream, object, usage, providerMetadata } = await streamObject({
+  model: yourModel,
+  messages: yourMessages,
+  schema: yourSchema
+});
 
-## Supported Models and Providers
+// Process the stream...
+for await (const partialObject of partialObjectStream) {
+  console.log(partialObject);
+}
 
-The package includes pricing information and token usage extraction for various LLM models:
+// Extract usage after completion
+const aiSdkUsageData = {
+  model: "gpt-4o",
+  usage,
+  providerMetadata
+};
 
-### ✅ Fully Supported Providers
-- **OpenAI**: Including cached tokens from `prompt_tokens_details.cached_tokens`
-- **Azure OpenAI**: Full pricing and cache support  
-- **Anthropic**: Cache reads, reasoning tokens
-- **Google AI**: Cached tokens and reasoning support
-- **Mistral**: Standard token usage extraction
+const tokenUsage = extractTokenUsageFromResponseBody(aiSdkUsageData);
+const costAnalysis = calculateRequestCost(
+  tokenUsage.model || "gpt-4o",
+  tokenUsage.promptCacheMissTokens,
+  tokenUsage.totalOutputTokens,
+  tokenUsage.promptCacheHitTokens,
+  tokenUsage.promptCacheWriteTokens
+);
+```
 
-### 🔧 Token Usage Formats Supported
-- OpenAI format: `usage.prompt_tokens_details.cached_tokens`
-- Anthropic format: `usage.cache_read_input_tokens`
-- AI SDK format: `providerMetadata.openai.cachedPromptTokens`
-- Standard format: Basic `prompt_tokens`, `completion_tokens`
+## Supported Providers
 
-### 💰 Cost Calculation Features
-- Cache read costs (discounted rates for cached tokens)
-- Cache write costs (one-time caching fees)
-- Reasoning token costs (o1 models)
-- Standard input/output token costs
+| Provider | Token Usage | Cached Tokens | Reasoning Tokens | Cost Calculation |
+|----------|-------------|---------------|------------------|------------------|
+| OpenAI | ✅ | ✅ | ✅ | ✅ |
+| Azure OpenAI | ✅ | ✅ | ✅ | ✅ |
+| Anthropic | ✅ | ✅ | ✅ | ✅ |
+| Google AI | ✅ | ✅ | ✅ | ✅ |
+| Mistral | ✅ | ❌ | ❌ | ✅ |
+
+## Token Usage Output Format
+
+All extraction functions return a standardized `TokenUsage` object:
+
+```typescript
+interface TokenUsage {
+  promptCacheMissTokens: number    // New input tokens (not from cache)
+  promptCacheHitTokens: number     // Input tokens served from cache
+  reasoningTokens: number          // Output tokens for reasoning (o1 models)
+  completionTokens: number         // Output tokens for completion
+  totalOutputTokens: number        // Total output tokens (reasoning + completion)
+  totalInputTokens: number         // Total input tokens (cache miss + cache hit)
+  promptCacheWriteTokens: number   // Tokens written to cache
+  model?: string                   // Model name (when available)
+}
+```
+
+## Cost Analysis Output Format
+
+The `calculateRequestCost` function returns detailed cost breakdown:
+
+```typescript
+interface RequestCostAnalysis {
+  actualCost: {
+    inputCost: number        // Cost for non-cached input tokens
+    outputCost: number       // Cost for output tokens
+    cacheReadCost: number    // Cost for reading cached tokens (discounted)
+    cacheWriteCost: number   // Cost for writing tokens to cache
+    totalCost: number        // Total actual cost
+  }
+  uncachedCost: {
+    inputCost: number        // What input would cost without caching
+    outputCost: number       // Output cost (same as actual)
+    totalCost: number        // Total cost if no caching was used
+  }
+  savings: {
+    inputSavings: number     // Amount saved on input costs
+    totalSavings: number     // Total amount saved by caching
+    percentSaved: number     // Percentage of cost saved
+  }
+  cacheStats: {
+    hitRate: number          // Cache hit rate (0-1)
+    totalInputTokens: number // Total input tokens processed
+    cachedTokens: number     // Tokens served from cache
+    uncachedTokens: number   // Tokens not in cache
+  }
+}
+```
 
 ## Troubleshooting
 
-### OpenAI Cached Tokens Not Showing?
+### OpenAI Cached Tokens Not Detected?
 
-If you're seeing `promptCacheHitTokens: 0` but know your requests are using cached tokens:
+Make sure your OpenAI responses include the `prompt_tokens_details` field:
 
-1. **Check OpenAI Response Format**: Look for `usage.prompt_tokens_details.cached_tokens` in your API responses
-2. **Update Library**: Make sure you're using the latest version with the cached tokens fix
-3. **Verify Response Structure**: Use `extractTokenUsageFromResponse` to see what's being extracted
-
-```typescript
-// Debug token extraction
-const debugUsage = extractTokenUsageFromResponse(yourResponse);
-console.log('Extracted usage:', debugUsage);
-console.log('Cache hits:', debugUsage.promptCacheHitTokens);
+```json
+{
+  "usage": {
+    "prompt_tokens": 2568,
+    "completion_tokens": 268,
+    "prompt_tokens_details": {
+      "cached_tokens": 1280
+    }
+  }
+}
 ```
 
-### Cost Calculations Seem Wrong?
+### Cost Seems Wrong?
 
-- **Cache costs**: Cached tokens typically cost 50% less than regular prompt tokens
-- **Model names**: Ensure you're using the exact model name for accurate pricing
-- **Token types**: Different token types (input/output/cache/reasoning) have different costs
+- **Cache costs**: Cached tokens typically cost 50% of regular input tokens
+- **Model names**: Use exact model names for accurate pricing
+- **Token breakdown**: Different token types have different rates
 
 ## Development
 
 ```bash
-# Install dependencies
 npm install
-
-# Build the package
 npm run build
-
-# Run tests
 npm test
-
-# Watch mode for development
-npm run dev
 ```
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run tests
-5. Submit a pull request
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-cost-utils",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "LLM token usage extraction and cost calculation utilities",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/unit/token-cost-calculations.test.ts
+++ b/test/unit/token-cost-calculations.test.ts
@@ -60,26 +60,84 @@ describe('getModelPricing', () => {
 })
 
 describe('calculateRequestCost', () => {
-  it('should calculate cost for input and output tokens', () => {
-    const cost = calculateRequestCost('gpt-4', 1000, 500)
+  it('should calculate cost analysis for input and output tokens', () => {
+    const analysis = calculateRequestCost('gpt-4', 1000, 500)
     // 1000 * 0.00003 = 0.03 cost for input
     // 500 * 0.00006 = 0.03 cost for output
-    expect(cost.inputCost).toBeCloseTo(0.03, 6)
-    expect(cost.outputCost).toBeCloseTo(0.03, 6)
-    expect(cost.totalCost).toBeCloseTo(0.06, 6)
+    expect(analysis.actualCost.inputCost).toBeCloseTo(0.03, 6)
+    expect(analysis.actualCost.outputCost).toBeCloseTo(0.03, 6)
+    expect(analysis.actualCost.totalCost).toBeCloseTo(0.06, 6)
+    
+    // No caching, so uncached cost should be the same
+    expect(analysis.uncachedCost.totalCost).toBeCloseTo(0.06, 6)
+    expect(analysis.savings.totalSavings).toBeCloseTo(0, 6)
+    expect(analysis.savings.percentSaved).toBeCloseTo(0, 6)
+    
+    // Cache stats for no caching
+    expect(analysis.cacheStats.hitRate).toBe(0)
+    expect(analysis.cacheStats.totalInputTokens).toBe(1000)
+    expect(analysis.cacheStats.cachedTokens).toBe(0)
+    expect(analysis.cacheStats.uncachedTokens).toBe(1000)
   })
 
-  it('should calculate cost with cache tokens', () => {
-    const cost = calculateRequestCost('claude-3-opus-20240229', 1000, 500, 200, 300)
-    // 1000 * 0.000015 = 0.015 cost for input
+  it('should calculate comprehensive cost analysis with cache tokens', () => {
+    const analysis = calculateRequestCost('claude-3-opus-20240229', 1000, 500, 200, 300)
+    // 1000 * 0.000015 = 0.015 cost for input (cache miss)
     // 500 * 0.000075 = 0.0375 cost for output
     // 200 * 0.000003 = 0.0006 cost for cache read
     // 300 * 0.00001875 = 0.005625 cost for cache write
-    expect(cost.inputCost).toBeCloseTo(0.015, 6)
-    expect(cost.outputCost).toBeCloseTo(0.0375, 6)
-    expect(cost.cacheReadCost).toBeCloseTo(0.0006, 6)
-    expect(cost.cacheWriteCost).toBeCloseTo(0.005625, 6)
-    expect(cost.totalCost).toBeCloseTo(0.058725, 5)
+    
+    // Actual costs (with caching applied)
+    expect(analysis.actualCost.inputCost).toBeCloseTo(0.015, 6)
+    expect(analysis.actualCost.outputCost).toBeCloseTo(0.0375, 6)
+    expect(analysis.actualCost.cacheReadCost).toBeCloseTo(0.0006, 6)
+    expect(analysis.actualCost.cacheWriteCost).toBeCloseTo(0.005625, 6)
+    expect(analysis.actualCost.totalCost).toBeCloseTo(0.058725, 5)
+    
+    // Uncached costs (as if no caching was used)
+    // Total input tokens: 1000 + 200 = 1200
+    // 1200 * 0.000015 = 0.018 cost for all input tokens
+    expect(analysis.uncachedCost.inputCost).toBeCloseTo(0.018, 6)
+    expect(analysis.uncachedCost.outputCost).toBeCloseTo(0.0375, 6)
+    expect(analysis.uncachedCost.cacheReadCost).toBe(0)
+    expect(analysis.uncachedCost.cacheWriteCost).toBe(0)
+    expect(analysis.uncachedCost.totalCost).toBeCloseTo(0.0555, 6)
+    
+    // Savings analysis
+    const expectedInputSavings = 0.018 - 0.015  // uncached input - actual input
+    expect(analysis.savings.inputSavings).toBeCloseTo(expectedInputSavings, 6)
+    const expectedTotalSavings = 0.0555 - 0.058725  // uncached total - actual total (note: cache write cost is added)
+    expect(analysis.savings.totalSavings).toBeCloseTo(expectedTotalSavings, 5)
+    const expectedPercentSaved = (expectedTotalSavings / 0.0555) * 100
+    expect(analysis.savings.percentSaved).toBeCloseTo(expectedPercentSaved, 3)
+    
+    // Cache statistics
+    expect(analysis.cacheStats.hitRate).toBeCloseTo(200 / 1200, 6) // 200 cached out of 1200 total
+    expect(analysis.cacheStats.totalInputTokens).toBe(1200)
+    expect(analysis.cacheStats.cachedTokens).toBe(200)
+    expect(analysis.cacheStats.uncachedTokens).toBe(1000)
+  })
+
+  it('should handle 100% cache hit scenario', () => {
+    const analysis = calculateRequestCost('claude-3-opus-20240229', 0, 500, 1000, 0)
+    
+    // All tokens served from cache
+    expect(analysis.actualCost.inputCost).toBe(0)
+    expect(analysis.actualCost.cacheReadCost).toBeCloseTo(0.003, 6) // 1000 * 0.000003
+    expect(analysis.actualCost.totalCost).toBeCloseTo(0.0405, 6) // output + cache read
+    
+    // Uncached would have cost more
+    expect(analysis.uncachedCost.inputCost).toBeCloseTo(0.015, 6) // 1000 * 0.000015
+    expect(analysis.uncachedCost.totalCost).toBeCloseTo(0.0525, 6) // input + output
+    
+    // Should show significant savings
+    expect(analysis.savings.totalSavings).toBeCloseTo(0.012, 6)
+    expect(analysis.savings.percentSaved).toBeCloseTo(22.857, 3) // roughly 22.86%
+    
+    // Perfect cache hit rate
+    expect(analysis.cacheStats.hitRate).toBe(1.0)
+    expect(analysis.cacheStats.cachedTokens).toBe(1000)
+    expect(analysis.cacheStats.uncachedTokens).toBe(0)
   })
 
   it('should throw an error for unknown model', () => {


### PR DESCRIPTION
## Breaking Changes (0.2.0)

### Cost Analysis Changes
- **BREAKING**: `calculateRequestCost` now returns `RequestCostAnalysis` instead of simple cost object
- Added cached vs uncached cost comparison:
  - `actualCost` - what you actually paid with caching
  - `uncachedCost` - what it would cost without caching
  - `savings` - amount and percentage saved
  - `cacheStats` - hit rate and token breakdown
- Removed deprecated `RequestCost` interface

### OpenAI Cached Tokens Fix
- Fixed extraction of `usage.prompt_tokens_details.cached_tokens` format
- Proper calculation of `promptCacheMissTokens` (total - cached)
- Backward compatible with other provider cache formats

## Documentation Updates

### Updated Examples
- All examples now use new 0.2.0 API
- Fixed AI SDK streaming example with proper `onFinish` callback
- Use realistic token values from actual responses

### Improved Structure
- Added provider support matrix
- Document `npm run download-model-prices` for pricing updates
- Replace troubleshooting with GitHub issue guidance
- Added interface documentation for return types

## Migration

Breaking change affects cost calculation return format - update your code to use the new `RequestCostAnalysis` structure instead of the old simple cost object. For details, see MIGRATION.md